### PR TITLE
Add more options (802.11r & disable IPv6)

### DIFF
--- a/roles/ansible_openwrtnetwork/templates/functions.jinja2
+++ b/roles/ansible_openwrtnetwork/templates/functions.jinja2
@@ -285,5 +285,8 @@ config interface "{{ key }}"
         option service "{{ value['service'] }}"
 {% endif %}
 {% endif %}
+{% if value['ipv6'] is defined %}
+        option ipv6 "{{ value['ipv6'] }}"
+{% endif %}
 {% endfor %}
 {% endmacro %}

--- a/roles/ansible_openwrtwireless/templates/wireless.jinja2
+++ b/roles/ansible_openwrtwireless/templates/wireless.jinja2
@@ -229,5 +229,38 @@ config wifi-iface "{{ key }}"
 {% if value.default_disabled is defined %}
 	option default_disabled "{{ value.default_disabled }}"
 {% endif %}
+{% if value.ieee80211r is defined %}
+	option ieee80211r "{{ value.ieee80211r }}"
+{% endif %}
+{% if value.nasid is defined %}
+	option nasid "{{ value.nasid }}"
+{% endif %}
+{% if value.mobility_domain is defined %}
+	option mobility_domain "{{ value.mobility_domain }}"
+{% endif %}
+{% if value.r0_key_lifetime is defined %}
+	option r0_key_lifetime "{{ value.r0_key_lifetime }}"
+{% endif %}
+{% if value.r1_key_holder is defined %}
+	option r1_key_holder "{{ value.r1_key_holder }}"
+{% endif %}
+{% if value.reassociation_deadline is defined %}
+	option reassociation_deadline "{{ value.reassociation_deadline }}"
+{% endif %}
+{% if value.r0kh is defined %}
+	option r0kh "{{ value.r0kh }}"
+{% endif %}
+{% if value.r1kh is defined %}
+	option r1kh "{{ value.r1kh }}"
+{% endif %}
+{% if value.pmk_r1_push is defined %}
+	option pmk_r1_push "{{ value.pmk_r1_push }}"
+{% endif %}
+{% if value.ft_over_ds is defined %}
+	option ft_over_ds "{{ value.ft_over_ds }}"
+{% endif %}
+{% if value.ft_psk_generate_local is defined %}
+	option ft_psk_generate_local "{{ value.ft_psk_generate_local }}"
+{% endif %}
 
 {% endfor %}


### PR DESCRIPTION
I needed a few more options that I didn't see in the collection. I have added the following:

- [All options listed for 802.11r](https://openwrt.org/docs/guide-user/network/wifi/basic#fast_bss_transition_options_80211r)
- [Single 'ipv6' option to disable IPv6 on an interface](https://openwrt.org/docs/guide-user/base-system/basic-networking#options_valid_for_all_protocol_types)

Options are strings directly copied from the linked documentation. 