### PR TITLE
IP rules and common interface options support

### DIFF
--- a/roles/ansible_openwrtnetwork/templates/functions.jinja2
+++ b/roles/ansible_openwrtnetwork/templates/functions.jinja2
@@ -188,6 +188,24 @@ config interface "{{ key }}"
         option device "{{ value['device'] }}"
 {% endif %}
         option proto "{{ value['proto'] }}"
+{% if value['mtu'] is defined %}
+        option mtu "{{ value['mtu'] }}"
+{% endif %}
+{% if value['ipv6'] is defined %}
+        option ipv6 "{{ value['ipv6'] }}"
+{% endif %}
+{% if value['force_link'] is defined %}
+        option force_link "{{ value['force_link'] }}"
+{% endif %}
+{% if value['disabled'] is defined %}
+        option disabled "{{ value['disabled'] }}"
+{% endif %}
+{% if value['ip4table'] is defined %}
+        option ip4table "{{ value['ip4table'] }}"
+{% endif %}
+{% if value['ip6table'] is defined %}
+        option ip6table "{{ value['ip6table'] }}"
+{% endif %}
 {% if value['proto'] == "wireguard" %}
 	option private_key "{{ value['wg_private_key'] }}"
 {% if value['wg_listen_port'] is defined %}
@@ -353,9 +371,7 @@ config interface "{{ key }}"
 {% endif %}
 {% if value['proto'] == "ppp" %}
         # PPP config
-{% if value['ipv6'] is defined %}
-	option ipv6 "value['ipv6']"
-{% else %}
+{% if value['ipv6'] is not defined %}
         option ipv6 "auto"
 {% endif %}
 {% if value['device'] is defined %}
@@ -370,9 +386,7 @@ config interface "{{ key }}"
 {% endif %}
 {% if value['proto'] == "pppoe" %}
         # PPPoE config
-{% if value['ipv6'] is defined %}
-	option ipv6 "value['ipv6']"
-{% else %}
+{% if value['ipv6'] is not defined %}
         option ipv6 "auto"
 {% endif %}
 {% if value['username'] is defined %}

--- a/roles/ansible_openwrtnetwork/templates/functions.jinja2
+++ b/roles/ansible_openwrtnetwork/templates/functions.jinja2
@@ -390,3 +390,65 @@ config interface "{{ key }}"
 {% endif %}
 {% endfor %}
 {% endmacro %}
+
+
+{% macro create_rules(rules, family) %}
+{% for key, value in rules.items() %}
+{% if family == 4 %}
+config rule '{{ key }}'
+{% elif family == 6 %}
+config rule6 '{{ key }}'
+{% endif %}
+
+{% if value['in'] is defined %}
+        option in "{{ value['in'] }}"
+{% endif %}
+{% if value['out'] is defined %}
+        option out "{{ value['out'] }}"
+{% endif %}
+{% if value['src'] is defined %}
+        option src "{{ value['src'] }}"
+{% endif %}
+{% if value['dest'] is defined %}
+        option dest "{{ value['dest'] }}"
+{% endif %}
+{% if value['tos'] is defined %}
+        option tos "{{ value['tos'] }}"
+{% endif %}
+{% if value['mark'] is defined %}
+        option mark "{{ value['mark'] }}"
+{% endif %}
+{% if value['uidrange'] is defined %}
+        option uidrange "{{ value['uidrange'] }}"
+{% endif %}
+{% if value['suppress_prefixlength'] is defined %}
+        option suppress_prefixlength "{{ value['suppress_prefixlength'] }}"
+{% endif %}
+{% if value['invert'] is defined %}
+        option invert "{{ value['invert'] }}"
+{% endif %}
+{% if value['priority'] is defined %}
+        option priority "{{ value['priority'] }}"
+{% endif %}
+{% if value['lookup'] is defined %}
+        option lookup "{{ value['lookup'] }}"
+{% endif %}
+{% if value['goto'] is defined %}
+        option goto "{{ value['goto'] }}"
+{% endif %}
+{% if value['action'] is defined %}
+        option action "{{ value['action'] }}"
+{% endif %}
+{% if value['disabled'] is defined %}
+        option disabled "{{ value['disabled'] }}"
+{% endif %}
+{% endfor %}
+{% endmacro %}
+
+{% macro create_rules4(allrules4) %}
+{{ create_rules(allrules4, 4)}}
+{% endmacro %}
+
+{% macro create_rules6(allrules6) %}
+{{ create_rules(allrules6, 6)}}
+{% endmacro %}

--- a/roles/ansible_openwrtnetwork/templates/network.jinja2
+++ b/roles/ansible_openwrtnetwork/templates/network.jinja2
@@ -40,3 +40,13 @@ config globals "globals"
 {% if openwrt_network_staticroutes6 is defined %}
 {{ functions.create_staticroutes6(openwrt_network_staticroutes6) }}
 {% endif %}
+
+{% if openwrt_network_rules4 is defined %}
+# IPv4 rules
+{{ functions.create_rules4(openwrt_network_rules4) }}
+{% endif %}
+
+{% if openwrt_network_rules6 is defined %}
+# IPv6 rules
+{{ functions.create_rules6(openwrt_network_rules6) }}
+{% endif %}


### PR DESCRIPTION
This PR adds support for:
- [IP Routing Rules](https://openwrt.org/docs/guide-user/network/routing/ip_rules)
- [Common interface options](https://openwrt.org/docs/guide-user/network/network_configuration#section_interface)